### PR TITLE
Add Justfile for building and pushing container images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@
 !docs/img/*.png
 !/docs/sbom/*.txt
 !/docs/sbom/*.cdx
+
+# allow justfile for building images
+!justfile

--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ build-server:
 
 build-tools:
 	for tool in {{TOOLS}}; do \
-		podman build -t "{{IMAGE_PREFIX}}/$$tool:{{IMAGE_VERSION}}" "./tools/$$tool"; \
+		podman build -t "{{IMAGE_PREFIX}}/$tool:{{IMAGE_VERSION}}" "./tools/$tool"; \
 	done
 
 build-all: build-server build-gui build-tools
@@ -29,7 +29,7 @@ push-server:
 
 push-tools:
 	for tool in {{TOOLS}}; do \
-		podman push "{{IMAGE_PREFIX}}/$$tool:{{IMAGE_VERSION}}"; \
+		podman push "{{IMAGE_PREFIX}}/$tool:{{IMAGE_VERSION}}"; \
 	done
 
 push-all: push-server push-gui push-tools

--- a/justfile
+++ b/justfile
@@ -1,0 +1,37 @@
+set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
+
+IMAGE_PREFIX := env_var_or_default("IMAGE_PREFIX", "localhost/borg")
+IMAGE_VERSION := env_var_or_default("IMAGE_VERSION", "latest")
+
+TOOLS := "droid siegfried tika magika mediainfo jhove verapdf odf-validator ooxml-validator"
+
+default:
+	@just --list
+
+build-gui:
+	podman build -t "{{IMAGE_PREFIX}}/gui:{{IMAGE_VERSION}}" ./gui
+
+build-server:
+	podman build -t "{{IMAGE_PREFIX}}/server:{{IMAGE_VERSION}}" ./server
+
+build-tools:
+	for tool in {{TOOLS}}; do \
+		podman build -t "{{IMAGE_PREFIX}}/$$tool:{{IMAGE_VERSION}}" "./tools/$$tool"; \
+	done
+
+build-all: build-server build-gui build-tools
+
+push-gui:
+	podman push "{{IMAGE_PREFIX}}/gui:{{IMAGE_VERSION}}"
+
+push-server:
+	podman push "{{IMAGE_PREFIX}}/server:{{IMAGE_VERSION}}"
+
+push-tools:
+	for tool in {{TOOLS}}; do \
+		podman push "{{IMAGE_PREFIX}}/$$tool:{{IMAGE_VERSION}}"; \
+	done
+
+push-all: push-server push-gui push-tools
+
+build-and-push-all: build-all push-all


### PR DESCRIPTION
This PR introduces a Justfile to simplify and standardize the process of building and pushing container images.
The new setup provides a set of convenient commands for:

- Building individual images (gui, server, and various tools)
- Building all images at once
- Pushing images to a container registry
- Combining build and push steps in a single command

The configuration supports customization via environment variables:

```IMAGE_PREFIX``` (default: localhost/borg)
```IMAGE_VERSION``` (default: latest)

Additionally, tool images are handled in a loop, making it easy to maintain and extend the list of supported tools without duplicating build/push logic.
Overall, this improves developer experience by reducing manual steps and ensuring consistent image naming and handling across the project.